### PR TITLE
Add games landing page and individual game placeholders

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,10 @@ app.use(express.json());
 // Routes
 // Use routes
 import homeRoutes from './routes/index.js';
+import gamesRoutes from './routes/games.js';
+
 app.use('/', homeRoutes);
+app.use('/games', gamesRoutes);
 // Middleware handling
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/src/controllers/games.js
+++ b/src/controllers/games.js
@@ -1,0 +1,17 @@
+export const getGamesList = (req, res) => {
+  res.render('games/index', {
+    title: 'Games Library',
+  });
+};
+
+export const getPowerGridTycoonPage = (req, res) => {
+  res.render('games/power-grid-tycoon', {
+    title: 'Power Grid Tycoon',
+  });
+};
+
+export const getTetrisPage = (req, res) => {
+  res.render('games/tetris', {
+    title: 'Tetris',
+  });
+};

--- a/src/routes/games.js
+++ b/src/routes/games.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import {
+  getGamesList,
+  getPowerGridTycoonPage,
+  getTetrisPage,
+} from '../controllers/games.js';
+
+const router = express.Router();
+
+router.get('/', getGamesList);
+router.get('/power-grid-tycoon', getPowerGridTycoonPage);
+router.get('/tetris', getTetrisPage);
+
+export default router;

--- a/src/views/games/index.ejs
+++ b/src/views/games/index.ejs
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %></title>
+    <link href="/css/output.css" rel="stylesheet" />
+  </head>
+  <body class="bg-white dark:bg-gray-900 min-h-screen">
+    <%- include('../partials/navbar') %>
+
+    <main class="container mx-auto px-4 py-12">
+      <header class="text-center mb-12">
+        <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Choose a Game to Play
+        </h1>
+        <p class="text-lg text-gray-700 dark:text-gray-300">
+          Pick one of the games below to jump right in. More titles will arrive soon!
+        </p>
+      </header>
+
+      <section class="grid gap-8 md:grid-cols-2">
+        <article class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 shadow-sm">
+          <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
+            Power Grid Tycoon
+          </h2>
+          <p class="text-gray-700 dark:text-gray-300 mb-6">
+            Build and manage your own energy empire. Balance resources, expand your grid, and keep the lights on for your city.
+          </p>
+          <a
+            href="/games/power-grid-tycoon"
+            class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-6 py-3 text-lg font-medium text-white transition hover:bg-indigo-500"
+          >
+            Launch Power Grid Tycoon
+          </a>
+        </article>
+
+        <article class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 shadow-sm">
+          <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
+            Tetris
+          </h2>
+          <p class="text-gray-700 dark:text-gray-300 mb-6">
+            The classic block-stacking challenge. Clear lines, rack up points, and test your reflexes in this timeless puzzle.
+          </p>
+          <a
+            href="/games/tetris"
+            class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-6 py-3 text-lg font-medium text-white transition hover:bg-indigo-500"
+          >
+            Launch Tetris
+          </a>
+        </article>
+      </section>
+    </main>
+
+    <script type="module" src="/js/index.js"></script>
+  </body>
+</html>

--- a/src/views/games/power-grid-tycoon.ejs
+++ b/src/views/games/power-grid-tycoon.ejs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %></title>
+    <link href="/css/output.css" rel="stylesheet" />
+  </head>
+  <body class="bg-white dark:bg-gray-900 min-h-screen">
+    <%- include('../partials/navbar') %>
+
+    <main class="container mx-auto px-4 py-12">
+      <header class="max-w-3xl mx-auto text-center mb-10">
+        <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Power Grid Tycoon
+        </h1>
+        <p class="text-lg text-gray-700 dark:text-gray-300">
+          This is the starting point for your Power Grid Tycoon experience. Add your gameplay layout, controls, and logic here.
+        </p>
+      </header>
+
+      <section class="max-w-4xl mx-auto space-y-6 text-gray-700 dark:text-gray-300">
+        <p>
+          Use this page to design the interface where players will plan their grid, allocate resources, and respond to changing demand.
+        </p>
+        <p>
+          You can include dashboards, maps, or interactive elements below. When you're ready, hook up your CSS and JavaScript to bring the tycoon management to life.
+        </p>
+      </section>
+    </main>
+
+    <script type="module" src="/js/power-grid-tycoon.js"></script>
+  </body>
+</html>

--- a/src/views/games/tetris.ejs
+++ b/src/views/games/tetris.ejs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %></title>
+    <link href="/css/output.css" rel="stylesheet" />
+  </head>
+  <body class="bg-white dark:bg-gray-900 min-h-screen">
+    <%- include('../partials/navbar') %>
+
+    <main class="container mx-auto px-4 py-12">
+      <header class="max-w-3xl mx-auto text-center mb-10">
+        <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          Tetris
+        </h1>
+        <p class="text-lg text-gray-700 dark:text-gray-300">
+          This page is ready for your Tetris implementation. Plug in your grid, controls, and scoring to recreate the classic experience.
+        </p>
+      </header>
+
+      <section class="max-w-4xl mx-auto space-y-6 text-gray-700 dark:text-gray-300">
+        <p>
+          Add your game board markup and any helper UI elements here. Consider a next-piece preview, score tracker, and level indicator.
+        </p>
+        <p>
+          When you're set to style and script the game, link to your CSS and JavaScript files to bring the falling blocks to life.
+        </p>
+      </section>
+    </main>
+
+    <script type="module" src="/js/tetris.js"></script>
+  </body>
+</html>

--- a/src/views/partials/navbar.ejs
+++ b/src/views/partials/navbar.ejs
@@ -1,54 +1,49 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <link href="/css/output.css" rel="stylesheet"/>
-</head>
-<body class="bg-white dark:bg-gray-900">
-  <nav class="bg-white dark:bg-gray-800 shadow">
-    <div class="w-full px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between h-16">
-        <!-- Left Side: Brand and Dark Mode Toggle -->
-        <div class="flex">
-          <!-- Brand -->
-          <a href="/" class="flex-shrink-0 flex items-center text-xl font-bold text-gray-800 dark:text-white">
-            MyApp
-          </a>
-          
-          <!-- Dark Mode Toggle -->
-          <button id="dark-mode-toggle" aria-label="Toggle Dark Mode" class="ml-4 m-2 my-4 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 flex items-center space-x-2">
-            <!-- Sun Icon (Light Mode) -->
-            <svg id="toggle-light-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                d="M12 3v1m0 16v1m8.66-8.66h-1M4.34 12h-1m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M12 5a7 7 0 000 14a7 7 0 000-14z" />
-            </svg>
-            <!-- Moon Icon (Dark Mode) -->
-            <svg id="toggle-dark-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
-            </svg>
-            <!-- Default Icon: Sun (for initial load) -->
-            <svg id="toggle-default-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
-                d="M12 3v1m0 16v1m8.66-8.66h-1M4.34 12h-1m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M12 5a7 7 0 000 14a7 7 0 000-14z" />
-            </svg>
-          </button>
-        </div>
-        
-        <!-- Center: Navigation Links -->
-        <div class="hidden sm:ml-6 sm:flex sm:space-x-8 items-center">
-          <ul class="flex space-x-4">
-            <li>
-              <a href="/Games" class="text-gray-800 dark:text-white hover:text-indigo-500 dark:hover:text-indigo-400 px-3 py-2 rounded-md text-lg font-medium">
-                Games
-              </a>
-            </li>
-          </ul>
-        </div>
-        
+<nav class="bg-white dark:bg-gray-800 shadow">
+  <div class="w-full px-4 sm:px-6 lg:px-8">
+    <div class="flex justify-between h-16">
+      <div class="flex">
+        <a href="/" class="flex-shrink-0 flex items-center text-xl font-bold text-gray-800 dark:text-white">
+          MyApp
+        </a>
+        <button
+          id="dark-mode-toggle"
+          aria-label="Toggle Dark Mode"
+          class="ml-4 m-2 my-4 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 flex items-center space-x-2"
+        >
+          <svg id="toggle-light-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 3v1m0 16v1m8.66-8.66h-1M4.34 12h-1m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M12 5a7 7 0 000 14a7 7 0 000-14z"
+            />
+          </svg>
+          <svg id="toggle-dark-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+          </svg>
+          <svg id="toggle-default-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 3v1m0 16v1m8.66-8.66h-1M4.34 12h-1m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M12 5a7 7 0 000 14a7 7 0 000-14z"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div class="hidden sm:ml-6 sm:flex sm:space-x-8 items-center">
+        <ul class="flex space-x-4">
+          <li>
+            <a
+              href="/games"
+              class="text-gray-800 dark:text-white hover:text-indigo-500 dark:hover:text-indigo-400 px-3 py-2 rounded-md text-lg font-medium"
+            >
+              Games
+            </a>
+          </li>
+        </ul>
       </div>
     </div>
-  </nav>
-  
-  <!-- Dark Mode Toggle Script -->
-</body>
-</html>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- add dedicated router and controllers for serving games content
- create games landing page with navigation to Power Grid Tycoon and Tetris placeholders
- provide base EJS templates for each game and simplify the shared navbar partial

## Testing
- npm test *(fails: existing suites require mocked modules that are not available)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917aa32614083278122633c3e453e61)