### PR TITLE
Add server-side scoring validation for Power Grid leaderboard

### DIFF
--- a/src/controllers/games.js
+++ b/src/controllers/games.js
@@ -1,4 +1,5 @@
 import { appendLeaderboardEntry, getLeaderboard } from '../services/powerGridLeaderboard.js';
+import { scorePowerGridRun } from '../services/powerGridScoring.js';
 
 export const getGamesList = (req, res) => {
   res.render('games/index', {
@@ -36,14 +37,14 @@ export const getPowerGridTycoonLeaderboardData = async (req, res, next) => {
 
 export const postPowerGridTycoonLeaderboardEntry = async (req, res, next) => {
   try {
-    const { score } = req.body ?? {};
-    if (!Number.isFinite(Number(score))) {
-      return res.status(400).json({ error: 'Score is required.' });
-    }
-    const entry = await appendLeaderboardEntry(req.body);
+    const computedEntry = scorePowerGridRun(req.body ?? {});
+    const entry = await appendLeaderboardEntry(computedEntry);
     const entries = await getLeaderboard(10);
     res.status(201).json({ entry, entries });
   } catch (error) {
+    if (error?.status === 400) {
+      return res.status(400).json({ error: error.message });
+    }
     next(error);
   }
 };

--- a/src/services/powerGridScoring.js
+++ b/src/services/powerGridScoring.js
@@ -1,0 +1,218 @@
+const DIFFICULTY_CONFIG = {
+  easy: { payoutMul: 1 },
+  normal: { payoutMul: 1 },
+  hard: { payoutMul: 0.9 },
+};
+
+const TELEMETRY_VERSION_MIN = 1;
+const MAX_FRAMES = 3600;
+const MAX_GENERATORS_PER_FRAME = 128;
+const SUPPLY_TOLERANCE = 1;
+const CAPACITY_TOLERANCE = 0.5;
+const EPSILON = 1e-3;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const toFiniteNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const badRequest = (message) => {
+  const error = new Error(message);
+  error.status = 400;
+  return error;
+};
+
+const readNonNegative = (value, label, index) => {
+  const num = toFiniteNumber(value);
+  if (num === null || num < 0) {
+    throw badRequest(`Invalid ${label} at frame ${index}.`);
+  }
+  return num;
+};
+
+const readFinite = (value, label, index) => {
+  const num = toFiniteNumber(value);
+  if (num === null) {
+    throw badRequest(`Invalid ${label} at frame ${index}.`);
+  }
+  return num;
+};
+
+const fuelMultiplierFor = (fuelMultipliers, fuel) => {
+  const num = toFiniteNumber(fuelMultipliers?.[fuel]);
+  if (num === null || num <= 0) return 1;
+  return clamp(num, 0.1, 10);
+};
+
+export function scorePowerGridRun(submission = {}) {
+  const safeName = String(submission?.name ?? '').trim().slice(0, 32) || 'Anonymous';
+  const runPayload = submission?.run && typeof submission.run === 'object' ? submission.run : submission;
+
+  if (!runPayload || typeof runPayload !== 'object') {
+    throw badRequest('Run data is required.');
+  }
+
+  const version = toFiniteNumber(runPayload.version ?? runPayload.telemetryVersion ?? 0);
+  if (version === null || version < TELEMETRY_VERSION_MIN) {
+    throw badRequest('Unsupported telemetry version.');
+  }
+
+  const difficultyKey = runPayload.difficulty;
+  if (!Object.prototype.hasOwnProperty.call(DIFFICULTY_CONFIG, difficultyKey)) {
+    throw badRequest('Invalid difficulty level.');
+  }
+
+  const frames = Array.isArray(runPayload.frames)
+    ? runPayload.frames
+    : Array.isArray(runPayload.telemetry)
+      ? runPayload.telemetry
+      : null;
+
+  if (!frames || frames.length === 0) {
+    throw badRequest('Telemetry frames are required.');
+  }
+
+  if (frames.length > MAX_FRAMES) {
+    throw badRequest('Telemetry submission is too large.');
+  }
+
+  const payoutMul = DIFFICULTY_CONFIG[difficultyKey].payoutMul;
+
+  let totalRevenue = 0;
+  let totalOpex = 0;
+  let totalEmissions = 0;
+  let uptimeTicks = 0;
+
+  frames.forEach((frame, frameIndex) => {
+    if (!frame || typeof frame !== 'object') {
+      throw badRequest(`Invalid telemetry frame at index ${frameIndex}.`);
+    }
+
+    const tickHours = readNonNegative(frame.tickHours, 'tick duration', frameIndex);
+    if (tickHours <= 0 || tickHours > 1) {
+      throw badRequest(`Invalid tick duration at frame ${frameIndex}.`);
+    }
+
+    const demand = readNonNegative(frame.demand, 'demand', frameIndex);
+    const supplyReported = readFinite(frame.supply, 'supply', frameIndex);
+    const price = readNonNegative(frame.price, 'price', frameIndex);
+    readFinite(frame.freq, 'frequency', frameIndex);
+
+    const generators = Array.isArray(frame.generators) ? frame.generators : null;
+    if (!generators || generators.length === 0) {
+      throw badRequest('Generator telemetry is missing.');
+    }
+
+    if (generators.length > MAX_GENERATORS_PER_FRAME) {
+      throw badRequest('Telemetry includes too many generators.');
+    }
+
+    const multipliers = frame.fuelMultipliers && typeof frame.fuelMultipliers === 'object'
+      ? frame.fuelMultipliers
+      : {};
+
+    let computedSupply = 0;
+    let frameOpex = 0;
+    let frameEmissions = 0;
+    let installedCap = 0;
+
+    generators.forEach((gen) => {
+      if (!gen || typeof gen !== 'object') {
+        throw badRequest(`Invalid generator telemetry at frame ${frameIndex}.`);
+      }
+
+      const cap = readNonNegative(gen.cap, 'generator capacity', frameIndex);
+      const actual = readFinite(gen.actual, 'generator output', frameIndex);
+      const opex = readNonNegative(gen.opex, 'generator operating cost', frameIndex);
+      const co2 = Math.max(0, toFiniteNumber(gen.co2) ?? 0);
+      const isBattery = !!gen.isBattery;
+      const on = !!gen.on;
+      const enabled = gen.enabled !== false;
+      const variable = !!gen.variable;
+      const fault = !!gen.fault;
+      const fuel = typeof gen.fuel === 'string' ? gen.fuel : '';
+
+      if (!isBattery) {
+        installedCap += cap;
+      }
+
+      if (!isBattery && actual < -EPSILON) {
+        throw badRequest('Generator output is inconsistent with telemetry.');
+      }
+
+      if (!isBattery && actual > cap + CAPACITY_TOLERANCE) {
+        throw badRequest('Generator output exceeds capacity.');
+      }
+
+      if (isBattery && Math.abs(actual) > cap + CAPACITY_TOLERANCE) {
+        throw badRequest('Battery output exceeds capacity.');
+      }
+
+      if (!isBattery && actual > EPSILON) {
+        if (!on || (!enabled && !variable) || fault) {
+          throw badRequest('Generator state does not allow positive output.');
+        }
+      }
+
+      if (variable && !on && actual > EPSILON) {
+        throw badRequest('Variable generator reported output while offline.');
+      }
+
+      if (fault && Math.abs(actual) > EPSILON) {
+        throw badRequest('Faulted generator reported output.');
+      }
+
+      if (isBattery) {
+        if (Math.abs(actual) > EPSILON) {
+          frameOpex += opex * 0.5;
+        }
+        computedSupply += actual;
+      } else {
+        if (on && (enabled || variable) && !fault && (actual > EPSILON || variable)) {
+          frameOpex += opex * fuelMultiplierFor(multipliers, fuel);
+        }
+        computedSupply += Math.max(0, actual);
+        if (actual > EPSILON) {
+          frameEmissions += (co2 / 1000) * actual * tickHours;
+        }
+      }
+    });
+
+    const targetCap = Math.max(80, 1.4 * Math.max(demand, 80));
+    if (installedCap > targetCap) {
+      frameOpex += (installedCap - targetCap) * 0.6;
+    }
+
+    if (Math.abs(supplyReported - computedSupply) > SUPPLY_TOLERANCE) {
+      throw badRequest('Supply telemetry does not match generator outputs.');
+    }
+
+    totalOpex += frameOpex;
+    totalEmissions += frameEmissions;
+
+    const delivered = Math.max(0, Math.min(demand, computedSupply));
+    const revenue = delivered * price * tickHours * payoutMul;
+    if (!Number.isFinite(revenue)) {
+      throw badRequest('Invalid revenue calculation.');
+    }
+    totalRevenue += revenue;
+
+    if (delivered >= demand - 0.1) {
+      uptimeTicks += 1;
+    }
+  });
+
+  const profitFloat = totalRevenue - totalOpex;
+  const uptimeRatio = uptimeTicks / frames.length;
+  const score = Math.round(profitFloat + uptimeRatio * 25000 - totalEmissions * 500);
+
+  return {
+    name: safeName,
+    score,
+    profit: Math.round(profitFloat),
+    uptime: Math.round(clamp(uptimeRatio * 100, 0, 100)),
+    emissions: Math.max(0, Math.round(totalEmissions)),
+  };
+}

--- a/tests/services/powerGridLeaderboard.test.js
+++ b/tests/services/powerGridLeaderboard.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const fsp = require('fs').promises;
+const os = require('os');
+const path = require('path');
+
+let appendLeaderboardEntry;
+let getLeaderboard;
+
+const tmpDir = path.join(os.tmpdir(), 'power-grid-leaderboard-tests');
+const tmpFile = path.join(tmpDir, 'leaderboard.json');
+
+beforeAll(() => {
+  process.env.POWER_GRID_LEADERBOARD_FILE = tmpFile;
+  const modulePath = path.join(__dirname, '../../src/services/powerGridLeaderboard.js');
+  let code = fs.readFileSync(modulePath, 'utf8');
+  code = code
+    .replace("import { promises as fs } from 'fs';", "const { promises: fs } = require('fs');")
+    .replace("import path from 'path';", "const path = require('path');")
+    .replace("import { fileURLToPath } from 'url';", "const { fileURLToPath } = require('url');")
+    .replace("import { randomUUID } from 'crypto';", "const { randomUUID } = require('crypto');")
+    .replace(
+      "const __filename = fileURLToPath(import.meta.url);\nconst __dirname = path.dirname(__filename);",
+      `const __filename = ${JSON.stringify(modulePath)};\nconst __dirname = path.dirname(__filename);`,
+    )
+    .replace(/export\s+async\s+function\s+getLeaderboard/g, 'async function getLeaderboard')
+    .replace(/export\s+async\s+function\s+appendLeaderboardEntry/g, 'async function appendLeaderboardEntry');
+  code += '\nmodule.exports = { appendLeaderboardEntry, getLeaderboard };';
+  const moduleObj = { exports: {} };
+  const wrapper = new Function('module', 'exports', 'require', code);
+  wrapper(moduleObj, moduleObj.exports, require);
+  ({ appendLeaderboardEntry, getLeaderboard } = moduleObj.exports);
+});
+
+beforeEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.POWER_GRID_LEADERBOARD_FILE;
+});
+
+describe('powerGridLeaderboard service', () => {
+  test('stores computed entries and clamps numeric fields', async () => {
+    const entry = await appendLeaderboardEntry({
+      name: 'Dana',
+      score: 25000.7,
+      profit: 10234.4,
+      uptime: 104.2,
+      emissions: -3,
+    });
+
+    expect(entry.name).toBe('Dana');
+    expect(entry.score).toBe(25001);
+    expect(entry.profit).toBe(10234);
+    expect(entry.uptime).toBe(100);
+    expect(entry.emissions).toBe(0);
+
+    const stored = await getLeaderboard();
+    expect(stored).toHaveLength(1);
+    expect(stored[0].score).toBe(25001);
+  });
+
+  test('rejects entries missing computed totals', async () => {
+    await expect(
+      appendLeaderboardEntry({ name: 'Eve', profit: 100, uptime: 80, emissions: 5 }),
+    ).rejects.toThrow('Leaderboard entry is missing score.');
+  });
+});

--- a/tests/services/powerGridScoring.test.js
+++ b/tests/services/powerGridScoring.test.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+let scorePowerGridRun;
+
+beforeAll(() => {
+  const modulePath = path.join(__dirname, '../../src/services/powerGridScoring.js');
+  let code = fs.readFileSync(modulePath, 'utf8');
+  code = code.replace(/export\s+function\s+scorePowerGridRun/g, 'function scorePowerGridRun');
+  code += '\nmodule.exports = { scorePowerGridRun };';
+  const moduleObj = { exports: {} };
+  const wrapper = new Function('module', 'exports', 'require', code);
+  wrapper(moduleObj, moduleObj.exports, require);
+  ({ scorePowerGridRun } = moduleObj.exports);
+});
+
+describe('scorePowerGridRun', () => {
+  const baseFrame = {
+    tick: 1,
+    demand: 50,
+    supply: 50,
+    price: 300,
+    freq: 60,
+    tickHours: 1 / 3600,
+    fuelMultipliers: { coal: 1, gas: 1 },
+    generators: [
+      {
+        id: 'coal-1',
+        fuel: 'coal',
+        cap: 60,
+        actual: 50,
+        on: true,
+        enabled: true,
+        variable: false,
+        fault: false,
+        isBattery: false,
+        opex: 55,
+        co2: 900,
+      },
+    ],
+  };
+
+  test('computes a leaderboard entry from telemetry frames', () => {
+    const run = {
+      version: 1,
+      difficulty: 'normal',
+      frames: [
+        baseFrame,
+        { ...baseFrame, tick: 2 },
+      ],
+    };
+
+    const result = scorePowerGridRun({ name: '  Alice  ', run });
+
+    expect(result).toEqual({
+      name: 'Alice',
+      score: 24886,
+      profit: -102,
+      uptime: 100,
+      emissions: 0,
+    });
+  });
+
+  test('rejects telemetry where reported supply and generator output diverge', () => {
+    const tampered = {
+      version: 1,
+      difficulty: 'normal',
+      frames: [
+        {
+          ...baseFrame,
+          supply: 120,
+        },
+      ],
+    };
+
+    expect(() => scorePowerGridRun({ name: 'Bob', run: tampered })).toThrow('Supply telemetry does not match generator outputs.');
+  });
+
+  test('rejects submissions with no telemetry frames', () => {
+    const emptyRun = {
+      version: 1,
+      difficulty: 'normal',
+      frames: [],
+    };
+
+    expect(() => scorePowerGridRun({ name: 'Carol', run: emptyRun })).toThrow('Telemetry frames are required.');
+  });
+});


### PR DESCRIPTION
## Summary
- capture telemetry frames in the Power Grid Tycoon client instead of sending precomputed totals
- add a server-side scoring routine that validates telemetry, recomputes results, and rejects tampered data before appending to the leaderboard
- tighten the leaderboard storage service and add targeted tests covering malformed submissions

## Testing
- npx jest tests/services/powerGridScoring.test.js tests/services/powerGridLeaderboard.test.js --runInBand
- npm test *(fails: missing userService/config modules in existing suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c87b7b148327a8e821a12212db05)