### PR TITLE
Increase Power Grid leaderboard payload limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "moduleDirectories": [
       "node_modules",
       "src"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^node:(.*)$": "$1"
+    }
   },
   "repository": {
     "type": "git",

--- a/src/app.js
+++ b/src/app.js
@@ -2,8 +2,6 @@ import express from 'express';
 import 'dotenv/config';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import  bodyParser from 'body-parser';
-import session from 'express-session';
 // Initialize Express app
 // Set view engine to EJS (you can use Pug or just static HTML if preferred)
 const __filename = fileURLToPath(import.meta.url);
@@ -12,8 +10,8 @@ const __dirname = path.dirname(__filename);
 const app = express();
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
-app.use(express.urlencoded({ extended: true }));
-app.use(express.json());
+app.use(express.urlencoded({ extended: true, limit: '2mb' }));
+app.use(express.json({ limit: '2mb' }));
 
 // get secret
 // Routes
@@ -35,8 +33,6 @@ app.use((req, res, next) => {
 // Middleware for serving static files (CSS, JS)
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/node_modules', express.static(path.join(__dirname, 'node_modules')));
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
 
 
 async function startServer() {
@@ -50,6 +46,8 @@ async function startServer() {
   app.listen(PORT, '0.0.0.0');
 }
 
-startServer();
+if (process.env.NODE_ENV !== 'test') {
+  startServer();
+}
 
-// Start server
+export default app;


### PR DESCRIPTION
## Summary
- raise the Express JSON and URL-encoded body size limits to accept large Power Grid leaderboard submissions
- remove redundant body-parser usage while exporting the configured Express app for reuse and testing
- add a Jest moduleNameMapper to normalize node: specifiers used by dependencies

## Testing
- npm test -- --runTestsByPath tests/services/powerGridLeaderboard.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917dca70e1c83279738102b8bb10797)