### PR TITLE
Allow overwriting loaded saves

### DIFF
--- a/src/controllers/games.js
+++ b/src/controllers/games.js
@@ -81,6 +81,8 @@ export const postPowerGridTycoonSaveState = async (req, res, next) => {
                 const save = await saveGameState({
                         name: req.body?.name,
                         state: req.body?.state,
+                        saveId: req.body?.saveId,
+                        code: req.body?.code,
                 });
 
                 res.status(201).json({ save });


### PR DESCRIPTION
## Summary
- allow save requests to reuse an existing save ID and access code when overwriting progress
- track loaded save metadata on the client so re-saving updates the same record
- add tests covering overwrite behavior and missing access code validation

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbc02ffd08327b2a6ef2e47a7b16f)