### PR TITLE
Clamp deficits in supply-demand balance

### DIFF
--- a/src/public/js/power-grid-sim-core.js
+++ b/src/public/js/power-grid-sim-core.js
@@ -46,7 +46,7 @@ export function finalizeSupplyDemandBalance({
     ? Math.max(0, Math.round(reserveMW))
     : Math.max(0, Math.round(adjustedDemand * reservePct));
   const oversupplyBeyondReserve = Math.max(0, oversupply - reserveTarget);
-  const deficit = adjustedDemand - supply;
+  const deficit = Math.max(0, adjustedDemand - supply);
 
   return {
     demand: adjustedDemand,


### PR DESCRIPTION
## Summary
- clamp finalized supply-demand deficit to zero to avoid negative values when supply exceeds demand
- maintain other balance metrics while keeping deficit usable for downstream logic

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbc5430c483278003a9ad1fe34f21)