### PR TITLE
Handle non-finite leaderboard values

### DIFF
--- a/src/services/powerGridLeaderboard.js
+++ b/src/services/powerGridLeaderboard.js
@@ -101,13 +101,23 @@ function sanitizeComputedEntry(raw) {
 		throw new Error('Computed leaderboard entry is required.');
 	}
 
-	const toFinite = (value, label) => {
-		const num = Number(value);
-		if (!Number.isFinite(num)) {
-			throw new Error(`Leaderboard entry is missing ${label}.`);
-		}
-		return num;
-	};
+        const toFinite = (value, label) => {
+                if (value === undefined || value === null) {
+                        throw new Error(`Leaderboard entry is missing ${label}.`);
+                }
+
+                const num = Number(value);
+
+                if (Number.isNaN(num)) {
+                        return 0;
+                }
+
+                if (!Number.isFinite(num)) {
+                        return num > 0 ? Number.MAX_SAFE_INTEGER : Number.MIN_SAFE_INTEGER;
+                }
+
+                return num;
+        };
 
 	const safeName = String(raw.name ?? '').trim().slice(0, 32) || 'Anonymous';
 	const score = toFinite(raw.score, 'score');

--- a/tests/services/powerGridLeaderboard.test.js
+++ b/tests/services/powerGridLeaderboard.test.js
@@ -97,6 +97,29 @@ describe('powerGridLeaderboard service', () => {
     );
   });
 
+  it('coerces non-finite values instead of rejecting leaderboard saves', async () => {
+    const entry = await appendLeaderboardEntry({
+      name: 'Overflowing Player With A Very Long Name',
+      score: Number.POSITIVE_INFINITY,
+      profit: '123abc',
+      uptime: 'NaN',
+      emissions: Number.NEGATIVE_INFINITY,
+    });
+
+    assert.equal(entry.name, 'Overflowing Player With A Very L');
+    assert.equal(entry.score, Number.MAX_SAFE_INTEGER);
+    assert.equal(entry.profit, 0);
+    assert.equal(entry.uptime, 0);
+    assert.equal(entry.emissions, 0);
+
+    const stored = await getLeaderboard(1);
+    assert.equal(stored.length, 1);
+    assert.equal(stored[0].score, Number.MAX_SAFE_INTEGER);
+    assert.equal(stored[0].profit, 0);
+    assert.equal(stored[0].uptime, 0);
+    assert.equal(stored[0].emissions, 0);
+  });
+
   it('allows concurrent leaderboard saves from separate processes', async () => {
     const scriptUrl = new URL('../fixtures/append-leaderboard-entry.js', import.meta.url);
 


### PR DESCRIPTION
## Summary
- allow sanitizeComputedEntry to coerce NaN and infinite computed totals to safe numeric ranges instead of throwing
- add regression test covering non-finite leaderboard payloads and truncated names

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbfa2b40c8327992f9fded0dbc934)